### PR TITLE
gradle_speedup -> master

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,5 @@
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.daemon=true
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
tweak gradle properties for better build performance
- enable daemon to run gradle as a service
- set jvmargs to recommended max RAM for significantly increased build performance

Source: http://kevinpelgrims.com/blog/2015/06/11/speeding-up-your-gradle-builds/
